### PR TITLE
refactor: use long ids for repositories

### DIFF
--- a/src/main/java/com/library/library/borrow/BorrowRepository.java
+++ b/src/main/java/com/library/library/borrow/BorrowRepository.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface BorrowRepository extends JpaRepository<Borrow, Integer> {
+public interface BorrowRepository extends JpaRepository<Borrow, Long> {
     public Optional<Borrow> findByBookAndMemberAndDelivery(Book book, Member member, boolean delivery);
 
     public List<Borrow> findAllByDeliverAndDateBetween(boolean deliver, LocalDate from, LocalDate to);

--- a/src/main/java/com/library/library/member/MemberRepository.java
+++ b/src/main/java/com/library/library/member/MemberRepository.java
@@ -3,5 +3,5 @@ package com.library.library.member;
 import com.library.library.borrow.Borrow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/library/library/member/MemberService.java
+++ b/src/main/java/com/library/library/member/MemberService.java
@@ -19,6 +19,6 @@ public class MemberService {
     }
 
     public Optional<Member> getMember(Long id){
-        return memberRepository.findById(Math.toIntExact(id));
+        return memberRepository.findById(id);
     }
 }

--- a/src/main/java/com/library/library/reservation/ReservationRepository.java
+++ b/src/main/java/com/library/library/reservation/ReservationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     public List<Reservation> findByBookAndNotifiedAndOrderByDateTimeDesc(Book book, boolean notified);
 
     public List<Reservation> findByMemberAndNotifiedAndOrderByDateTimeDesc(Member member, boolean notified);


### PR DESCRIPTION
## Summary
- use `Long` IDs across Borrow, Member, and Reservation repositories
- simplify `MemberService#getMember` to query repositories using `Long`

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_68b4d2f112bc832793a00226459d954b