### PR TITLE
Fix repository query method names

### DIFF
--- a/src/main/java/com/library/library/borrow/BorrowRepository.java
+++ b/src/main/java/com/library/library/borrow/BorrowRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BorrowRepository extends JpaRepository<Borrow, Integer> {
-    public Optional<Borrow> findByBookAndMemberAndDelivery(Book book, Member member, boolean delivery);
+    public Optional<Borrow> findByBookAndMemberAndDeliver(Book book, Member member, boolean deliver);
 
     public List<Borrow> findAllByDeliverAndDateBetween(boolean deliver, LocalDate from, LocalDate to);
 

--- a/src/main/java/com/library/library/borrow/BorrowService.java
+++ b/src/main/java/com/library/library/borrow/BorrowService.java
@@ -27,7 +27,7 @@ public class BorrowService {
     }
 
     public Optional<Borrow> getByBookAndMember(Book book, Member member){
-        return this.borrowRepository.findByBookAndMemberAndDelivery(book, member, false);
+        return this.borrowRepository.findByBookAndMemberAndDeliver(book, member, false);
     }
 
     public synchronized Borrow createBorrow(Borrow borrow){

--- a/src/main/java/com/library/library/reservation/ReservationRepository.java
+++ b/src/main/java/com/library/library/reservation/ReservationRepository.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
-    public List<Reservation> findByBookAndNotifiedAndOrderByDateTimeDesc(Book book, boolean notified);
+    public List<Reservation> findByBookAndNotifiedOrderByDateTimeDesc(Book book, boolean notified);
 
-    public List<Reservation> findByMemberAndNotifiedAndOrderByDateTimeDesc(Member member, boolean notified);
+    public List<Reservation> findByMemberAndNotifiedOrderByDateTimeDesc(Member member, boolean notified);
 }

--- a/src/main/java/com/library/library/reservation/ReservationService.java
+++ b/src/main/java/com/library/library/reservation/ReservationService.java
@@ -24,7 +24,7 @@ public class ReservationService {
     }
 
     public Reservation callPendingNotifications(Borrow borrow){
-        List<Reservation> reservations = this.reservationRepository.findByBookAndNotifiedAndOrderByDateTimeDesc(borrow.getBook(), false);
+        List<Reservation> reservations = this.reservationRepository.findByBookAndNotifiedOrderByDateTimeDesc(borrow.getBook(), false);
 
         if(reservations.isEmpty()){
             return null;
@@ -39,7 +39,7 @@ public class ReservationService {
     }
 
     public List<Reservation> returnPendingNotifications(Member member){
-        return this.reservationRepository.findByMemberAndNotifiedAndOrderByDateTimeDesc(member, false);
+        return this.reservationRepository.findByMemberAndNotifiedOrderByDateTimeDesc(member, false);
     }
 
 


### PR DESCRIPTION
## Summary
- Rename BorrowRepository query to use `Deliver`
- Simplify ReservationRepository query names by removing extra `And`
- Update services to use new method names

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d30545c083278b8113af3932b4f7