### PR TITLE
Handle out-of-stock scenarios

### DIFF
--- a/src/main/java/com/library/library/GlobalExceptionHandler.java
+++ b/src/main/java/com/library/library/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.library.library;
+
+import com.library.library.book.OutOfStockException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(OutOfStockException.class)
+    public ResponseEntity<String> handleOutOfStockException(OutOfStockException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/library/library/book/BookService.java
+++ b/src/main/java/com/library/library/book/BookService.java
@@ -28,13 +28,13 @@ public class BookService {
     }
 
     public synchronized Book decreaseStock(Book book){
-        if (book.getStock() < 0){
-            throw new RuntimeException("There is not stock available for this book");
+        if (book.getStock() <= 0) {
+            throw new OutOfStockException("There is not stock available for this book");
         }
 
-       book.setStock(book.getStock() - 1);
+        book.setStock(book.getStock() - 1);
 
-       return this.bookRepository.save(book);
+        return this.bookRepository.save(book);
     }
 
     public synchronized Book increaseStock(Book book){

--- a/src/main/java/com/library/library/book/OutOfStockException.java
+++ b/src/main/java/com/library/library/book/OutOfStockException.java
@@ -1,0 +1,7 @@
+package com.library.library.book;
+
+public class OutOfStockException extends RuntimeException {
+    public OutOfStockException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent book stock from dropping below zero by throwing custom `OutOfStockException`
- return HTTP 409 Conflict when trying to borrow a book with no remaining copies

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0c58f3c8327809cc26e5903376b