### PR TITLE
Avoid duplicate borrows

### DIFF
--- a/src/main/java/com/library/library/borrow/BorrowService.java
+++ b/src/main/java/com/library/library/borrow/BorrowService.java
@@ -31,6 +31,13 @@ public class BorrowService {
     }
 
     public synchronized Borrow createBorrow(Borrow borrow){
+        Optional<Borrow> existing = this.borrowRepository
+                .findByBookAndMemberAndDeliver(borrow.getBook(), borrow.getMember(), false);
+
+        if(existing.isPresent()){
+            return existing.get();
+        }
+
         this.bookService.decreaseStock(borrow.getBook());
 
         return borrowRepository.save(borrow);


### PR DESCRIPTION
## Summary
- Prevent duplicate borrow creation by reusing existing undelivered borrow records and only reducing stock for new borrows.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0d3c0008327a3a2163b1c210c9e