### PR TITLE
Fix borrow record check

### DIFF
--- a/src/main/java/com/library/library/borrow/BorrowResource.java
+++ b/src/main/java/com/library/library/borrow/BorrowResource.java
@@ -55,7 +55,7 @@ public class BorrowResource {
 
         Optional<Borrow> borrowOptional = borrowService.getByBookAndMember(bookOptional.get(), memberOptional.get());
 
-        if(bookOptional.isEmpty()){
+        if(borrowOptional.isEmpty()){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("borrow not found");
         }
 


### PR DESCRIPTION
## Summary
- fix returnBorrow method to check borrowOptional instead of bookOptional

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; could not transfer org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0ea52548327839ac66edf53801b