### PR TITLE
Sort reservations ascending for notifications

### DIFF
--- a/src/main/java/com/library/library/reservation/ReservationRepository.java
+++ b/src/main/java/com/library/library/reservation/ReservationRepository.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
-    public List<Reservation> findByBookAndNotifiedOrderByDateTimeDesc(Book book, boolean notified);
+    public List<Reservation> findByBookAndNotifiedOrderByDateTimeAsc(Book book, boolean notified);
 
     public List<Reservation> findByMemberAndNotifiedOrderByDateTimeDesc(Member member, boolean notified);
 }

--- a/src/main/java/com/library/library/reservation/ReservationService.java
+++ b/src/main/java/com/library/library/reservation/ReservationService.java
@@ -24,7 +24,7 @@ public class ReservationService {
     }
 
     public Reservation callPendingNotifications(Borrow borrow){
-        List<Reservation> reservations = this.reservationRepository.findByBookAndNotifiedOrderByDateTimeDesc(borrow.getBook(), false);
+        List<Reservation> reservations = this.reservationRepository.findByBookAndNotifiedOrderByDateTimeAsc(borrow.getBook(), false);
 
         if(reservations.isEmpty()){
             return null;


### PR DESCRIPTION
## Summary
- rename repository query to sort reservations by date ascending
- use ascending lookup to notify earliest reservation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0febd5c83278cdb91e343609077