### PR TITLE
Check stock before creating reservation

### DIFF
--- a/src/main/java/com/library/library/reservation/ReservationResource.java
+++ b/src/main/java/com/library/library/reservation/ReservationResource.java
@@ -39,7 +39,13 @@ public class ReservationResource {
                     .body("memberId or isbn not found");
         }
 
-        Reservation reservation = reservationService.createReservation(new Reservation(bookOptional.get(),
+        Book book = bookOptional.get();
+        if (book.getStock() > 0) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Book is currently in stock");
+        }
+
+        Reservation reservation = reservationService.createReservation(new Reservation(book,
                 memberOptional.get()));
 
         return ResponseEntity.status(HttpStatus.OK).body(reservation);


### PR DESCRIPTION
## Summary
- Ensure reservations are only created when a book has no remaining stock
- Return HTTP 409 conflict if the requested book is still available

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e10d160883279a70aedeef955603