### PR TITLE
Add top borrowed books report endpoint

### DIFF
--- a/src/main/java/com/library/library/borrow/BorrowRepository.java
+++ b/src/main/java/com/library/library/borrow/BorrowRepository.java
@@ -2,7 +2,9 @@ package com.library.library.borrow;
 
 import com.library.library.book.Book;
 import com.library.library.member.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,4 +16,7 @@ public interface BorrowRepository extends JpaRepository<Borrow, Integer> {
     public List<Borrow> findAllByDeliverAndDateBetween(boolean deliver, LocalDate from, LocalDate to);
 
     public List<Borrow> findAllByDeliverAndDateLessThanEqual(boolean deliver, LocalDate date);
+
+    @Query("SELECT b.book FROM Borrow b GROUP BY b.book ORDER BY COUNT(b) DESC")
+    List<Book> findTopBorrowedBooks(Pageable pageable);
 }

--- a/src/main/java/com/library/library/borrow/BorrowService.java
+++ b/src/main/java/com/library/library/borrow/BorrowService.java
@@ -6,6 +6,7 @@ import com.library.library.book.BookService;
 import com.library.library.member.Member;
 import com.library.library.reservation.Reservation;
 import com.library.library.reservation.ReservationService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -65,6 +66,10 @@ public class BorrowService {
         LocalDate now = LocalDate.now();
 
         return borrowRepository.findAllByDeliverAndDateLessThanEqual(false, now).stream().map(Borrow::getMember).toList();
+    }
+
+    public List<Book> getTopBorrowedBooks(int limit){
+        return borrowRepository.findTopBorrowedBooks(PageRequest.of(0, limit));
     }
 
 

--- a/src/main/java/com/library/library/reports/ReportResources.java
+++ b/src/main/java/com/library/library/reports/ReportResources.java
@@ -5,7 +5,7 @@ import com.library.library.book.Book;
 import com.library.library.borrow.BorrowService;
 import com.library.library.member.Member;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -13,7 +13,11 @@ import java.util.List;
 @RestController
 public class ReportResources {
 
-    private BorrowService borrowService;
+    private final BorrowService borrowService;
+
+    public ReportResources(BorrowService borrowService){
+        this.borrowService = borrowService;
+    }
 
     @GetMapping("/reports/overdue")
     public List<Member> overuse(){
@@ -21,7 +25,7 @@ public class ReportResources {
     }
 
     @GetMapping("/reports/top-books")
-    public List<Book> topBook(@PathVariable int limit){
-        throw new UnsupportedOperationException();
+    public List<Book> topBook(@RequestParam(defaultValue = "5") int limit){
+        return borrowService.getTopBorrowedBooks(limit);
     }
 }


### PR DESCRIPTION
## Summary
- expose `/reports/top-books` endpoint returning most borrowed books with optional `limit` query parameter
- add repository query to count borrows per book and fetch top results
- wire `BorrowService` into `ReportResources` via constructor and implement service method

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e13620488327bb6d202c2328e0a0