### PR TITLE
Add due date tracking and scheduled due notifications

### DIFF
--- a/src/main/java/com/library/library/LibraryApplication.java
+++ b/src/main/java/com/library/library/LibraryApplication.java
@@ -2,8 +2,10 @@ package com.library.library;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LibraryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/library/library/borrow/Borrow.java
+++ b/src/main/java/com/library/library/borrow/Borrow.java
@@ -28,6 +28,8 @@ public class Borrow {
 
     private LocalDate date;
 
+    private LocalDate dueDate;
+
     private int duration = 7;
 
     private boolean deliver = false;
@@ -40,6 +42,7 @@ public class Borrow {
         this.member = member;
         this.date = LocalDate.now();
         this.duration = 7;
+        this.dueDate = this.date.plusDays(this.duration);
         this.deliver = false;
     }
 
@@ -73,6 +76,7 @@ public class Borrow {
 
     public void setDate(LocalDate date) {
         this.date = date;
+        this.dueDate = this.date.plusDays(this.duration);
     }
 
     public int getDuration() {
@@ -81,6 +85,7 @@ public class Borrow {
 
     public void setDuration(int duration) {
         this.duration = duration;
+        this.dueDate = this.date.plusDays(this.duration);
     }
 
     public boolean isDeliver() {
@@ -91,6 +96,14 @@ public class Borrow {
         this.deliver = deliver;
     }
 
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
     @Override
     public String toString() {
         return "Borrow{" +
@@ -98,6 +111,7 @@ public class Borrow {
                 ", book=" + book +
                 ", member=" + member +
                 ", date=" + date +
+                ", dueDate=" + dueDate +
                 ", duration=" + duration +
                 ", deliver=" + deliver +
                 '}';

--- a/src/main/java/com/library/library/borrow/BorrowRepository.java
+++ b/src/main/java/com/library/library/borrow/BorrowRepository.java
@@ -14,4 +14,6 @@ public interface BorrowRepository extends JpaRepository<Borrow, Integer> {
     public List<Borrow> findAllByDeliverAndDateBetween(boolean deliver, LocalDate from, LocalDate to);
 
     public List<Borrow> findAllByDeliverAndDateLessThanEqual(boolean deliver, LocalDate date);
+
+    public List<Borrow> findAllByDeliver(boolean deliver);
 }

--- a/src/main/java/com/library/library/borrow/BorrowService.java
+++ b/src/main/java/com/library/library/borrow/BorrowService.java
@@ -56,9 +56,11 @@ public class BorrowService {
     }
 
     public List<Borrow> getAllByRule(){
-        LocalDate nowMinus2Days = LocalDate.now().minusDays(2);
+        LocalDate now = LocalDate.now();
 
-        return borrowRepository.findAllByDeliverAndDateLessThanEqual(false, nowMinus2Days);
+        return borrowRepository.findAllByDeliver(false).stream()
+                .filter(borrow -> !borrow.getDueDate().minusDays(2).isAfter(now))
+                .toList();
     }
 
     public List<Member> getAllMemberWithOverDue(){

--- a/src/main/java/com/library/library/notification/NotificationService.java
+++ b/src/main/java/com/library/library/notification/NotificationService.java
@@ -4,10 +4,9 @@ package com.library.library.notification;
 import com.library.library.borrow.Borrow;
 import com.library.library.borrow.BorrowService;
 import com.library.library.reservation.Reservation;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 
 @Service
@@ -20,6 +19,7 @@ public class NotificationService {
     }
 
 
+    @Scheduled(cron = "0 0 0 * * *")
     public void notifyByDueDay(){
         // run everyday check the filter the list of borrows that are due for two days
 


### PR DESCRIPTION
## Summary
- track each borrow's due date and recalculate when date or duration changes
- filter borrows due within two days and schedule daily notifications
- enable scheduling in the application

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e140c3288327af9cb8af08483bff